### PR TITLE
Explicitly include <string> stdlib.

### DIFF
--- a/src/miscfilters.cpp
+++ b/src/miscfilters.cpp
@@ -26,6 +26,7 @@
 #include <limits>
 #include <memory>
 #include <stdexcept>
+#include <string>
 #include <vector>
 #include <VapourSynth4.h>
 #include <VSHelper4.h>


### PR DESCRIPTION
clang 13 complains about references to std::basic_string. Not sure if prior versions automatically imported the string lib or if it had been part of one of the removed .h deps in recent commits.

Example:
```
c++ -Ilibmiscfilters.dylib.p -I. -I.. -I/usr/local/Cellar/vapoursynth/57/include/vapoursynth -I/usr/local/Cellar/zimg/3.0.3/include -fvisibility=hidden -fcolor-diagnostics -DNDEBUG -Wall -Winvalid-pch -Wnon-virtual-dtor -Wextra -std=c++14 -O3 -march=cascadelake -O3 -MD -MQ libmiscfilters.dylib.p/src_miscfilters.cpp.o -MF libmiscfilters.dylib.p/src_miscfilters.cpp.o.d -o libmiscfilters.dylib.p/src_miscfilters.cpp.o -c ../src/miscfilters.cpp
../src/miscfilters.cpp:34:13: error: implicit instantiation of undefined template 'std::basic_string<char>'
std::string operator""_s(const char *str, size_t len) { return{ str, len }; }
```

This change explicitly includes the `<string>` library.